### PR TITLE
Add server script to run from client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "server": "json-server -p3001 --watch db.json"
+    "server": "cd ../server && node index.js"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Currently, running both the frontend and backend requires you to run 'npm start' in the frontend and 'node index.js' in the backend folders. This allows the frontend folder to run the server directly from the frontend folder by adding a shortcut via 'npm run server.'

Nonfunctional change.