### PR TITLE
added swagger.json and swagger dependencies

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -10,10 +10,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "axios": "^0.27.2",
+    "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "mongoose": "^7.0.1",
-    "axios": "^0.27.2",
-    "cors": "^2.8.5"
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^4.6.2"
   }
 }


### PR DESCRIPTION
The added swagger packages will let us view the swagger API documentation from the server with the /api-docs endpoint.