### PR TITLE
Add Concurrently

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "server": "cd ../server && node index.js"
+    "server": "cd ../server && node index.js",
+    "both": "concurrently \"react-scripts start\" \"cd ../server && node index.js\""
   },
   "eslintConfig": {
     "extends": [
@@ -41,6 +42,7 @@
     ]
   },
   "devDependencies": {
+    "concurrently": "^8.0.1",
     "eslint": "^8.36.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.27.5",

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -127,7 +127,7 @@ router.post('/user/time', async (req, res, next) => {
                     for(let i=0; i<7; i++) {
                         let hour_work = 0;
 
-                        console.log(checking_date);
+                        // console.log(checking_date);
 
                         let found = entries_of_this_week.find((e) => {
                             const entry_date = new Date(e.date);


### PR DESCRIPTION
Now, you can run the server and the frontend in one command, "npm run both"

This also removes a debug printout from the backend from the get time endpoint to reduce clutter in the terminal.