### PR TITLE
Parametize subordinate ID

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -8,14 +8,14 @@ import ErrorPage from './pages/ErrorPage'
 import { useCookies } from 'react-cookie'
 
 const App = () => {
-  const [cookies, setCookie, removeCookie] = useCookies(['data', 'subData'])
+  const [cookies, setCookie, removeCookie] = useCookies(['data'])
 
   return (
     <Routes>
       <Route path='/' element={<Login cookies = {cookies} cookieSetter = {setCookie}/>}/>
       <Route path='/time' element={<EmployeePage employeeData={cookies.data} employeeDataUpdater = {setCookie} cookieReset={removeCookie} cookies={cookies}/>}/>
       <Route path='/manager/view' element={<ManagerPage employeeData={cookies.data} employeeDataUpdater={setCookie} cookieReset={removeCookie} cookies={cookies}/>}/>
-      <Route path='/manager/view/id' element={<ManagerIndividualPage employeeData={cookies.data} employeeDataUpdater={setCookie} subordinateData={cookies.subData} cookieReset={removeCookie} cookies={cookies}/>}/>
+      <Route path='/manager/view/:id' element={<ManagerIndividualPage employeeData={cookies.data} employeeDataUpdater={setCookie} cookieReset={removeCookie} cookies={cookies}/>}/>
       <Route path='/serverdown' element={<ServerDownPage/>}/>
       <Route path='*' element={<ErrorPage/>}/>
     </Routes>

--- a/client/src/components/EmployeeTable.js
+++ b/client/src/components/EmployeeTable.js
@@ -6,7 +6,7 @@ const EmployeeTable = ({ employeeObjs, selectionUpdater }) => {
   const navigator = useNavigate()
   const handleRowClick = (employeeObj) => (e) => {
     selectionUpdater('subData', employeeObj, { path: '/', expires: new Date(Date.now() + 50000000) })
-    navigator('/manager/view/id')
+    navigator(`/manager/view/${employeeObj.employeeId}`)
   }
   // the slice is to make a copy, since sort is in place
   const sortedEmployees = employeeObjs.slice().sort((e1, e2) => e1.employeeId - e2.employeeId)

--- a/client/src/pages/ManagerIndividualPage.js
+++ b/client/src/pages/ManagerIndividualPage.js
@@ -1,21 +1,36 @@
 import { useState, useEffect } from 'react'
 import NavigationTab from '../components/NavigationTab'
 import LogoutButton from '../components/LogoutButton'
-import { useNavigate } from 'react-router-dom'
+import requests from '../services/requests'
+import { useNavigate, useParams } from 'react-router-dom'
 import PaymentHistoryWindow from '../components/PaymentHistoryWindow'
 
-const ManagerIndividualPage = ({ employeeData, employeeDataUpdater, subordinateData, cookieReset, cookies }) => {
+const ManagerIndividualPage = ({ employeeData, employeeDataUpdater, cookieReset, cookies }) => {
   const [isListPresent, setListPresence] = useState(false)
+  const [subordinateData, setSubordinateData] = useState(undefined)
+  const { id: subordinateId } = useParams()
   const navigator = useNavigate()
+
+  const fetchEmployee = async (employeeId, companyId) => {
+    try {
+      const resp = await requests.getEmployee(employeeId, companyId)
+      setSubordinateData(resp.data.value)
+      return resp
+    } catch (e) {
+      console.log(e)
+    }
+  }
+
   useEffect(() => {
     if (cookies.data === undefined) {
       // Display login form
       navigator('/')
+      return
     }
+    fetchEmployee(subordinateId, employeeData.companyId)
   }, [])
-  console.log(subordinateData)
 
-  return (cookies.data === undefined)
+  return ((cookies.data === undefined) || subordinateData === undefined)
     ? <div/>
     : (<div className='page-container'>
         <LogoutButton employeeDataUpdater={employeeDataUpdater} cookieReset={cookieReset}/>

--- a/client/src/services/requests.js
+++ b/client/src/services/requests.js
@@ -2,6 +2,17 @@ import axios from 'axios'
 
 const baseURL = 'http://localhost:5000'
 
+const getEmployee = async (employeeId, companyId) => {
+  try {
+    return axios.post(`${baseURL}/employeeGet`, {
+      employeeId, companyId
+    })
+  } catch (e) {
+    console.log(`Error detected: ${e}`)
+    throw e
+  }
+}
+
 const validateLogin = async (username, password) => {
   try {
     return axios.post(`${baseURL}/login`, {
@@ -63,6 +74,6 @@ const getAllTime = (employeeId, companyId) => {
   }
 }
 
-const methods = { validateLogin, getManagerViewData, sendTimeData, getTimeData, getAllTime } // Recent React needs this to be a separate obj
+const methods = { validateLogin, getEmployee, getManagerViewData, sendTimeData, getTimeData, getAllTime } // Recent React needs this to be a separate obj
 
 export default methods


### PR DESCRIPTION
Cookies no longer need to contain subordinate ID, since this is now contained in the parametized URL. This lets you bookmark pages, and to jump between employees without having to reset the cookie.